### PR TITLE
Add missing meta.mainProgram attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
           individualCrateArgs
           // {
             pname = "envoluntary";
+            meta.mainProgram = "envoluntary";
             cargoExtraArgs = "-p envoluntary";
             src = fileSetForCrate;
           }


### PR DESCRIPTION
When consuming this flake in home-manager, I get the following error:

>evaluation warning: getExe: Package "envoluntary-0.1.0" does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".

This adds the missing attribute. I've tested it in my own flake and confirmed the warning is gone, and have confirmed the command works correctly.

Passes `check-all` and `format-all`. Not sure if there's anything I missed.